### PR TITLE
fix arm64 build

### DIFF
--- a/library/unix/build.mk
+++ b/library/unix/build.mk
@@ -2,7 +2,7 @@ CFLAGS +=
 CXXFLAGS := $(CFLAGS) -std=gnu++17 -fpic
 DEFINES += -DTRACY_ENABLE
 INCLUDES :=
-LIBS := -lpthread -ldl
+LIBS := -lpthread -ldl -ltbb
 PROJECT := libtracy
 IMAGE := $(PROJECT)-$(BUILD).so
 

--- a/profiler/build/unix/build.mk
+++ b/profiler/build/unix/build.mk
@@ -2,7 +2,7 @@ CFLAGS +=
 CXXFLAGS := $(CFLAGS) -std=c++17
 DEFINES += -DIMGUI_IMPL_OPENGL_LOADER_GL3W
 INCLUDES := $(shell pkg-config --cflags glfw3 freetype2 capstone) -I../../../imgui -I../../libs/gl3w
-LIBS := $(shell pkg-config --libs glfw3 freetype2 capstone) -lpthread -ldl
+LIBS := $(shell pkg-config --libs glfw3 freetype2 capstone) -lpthread -ldl -ltbb
 PROJECT := Tracy
 IMAGE := $(PROJECT)-$(BUILD)
 

--- a/profiler/build/unix/release.mk
+++ b/profiler/build/unix/release.mk
@@ -1,6 +1,6 @@
 ARCH := $(shell uname -m)
 
-CFLAGS := -O3 -s -march=native
+CFLAGS := -O3 -s
 DEFINES := -DNDEBUG
 BUILD := release
 


### PR DESCRIPTION
When compiling on Tegra using clang I got this error:

´´´
clang: error: the clang compiler does not support '-march=native'
´´´

This PR is a minimal fix, just removing -march=native from the offending Makefile..